### PR TITLE
調整檔案上傳 API 端點，將臨時檔案上傳的 URL 從 `/upload-temp` 更改為 `/upload`，以統一上傳流程並提升系…

### DIFF
--- a/frontend/src/context/TranscriptionContext.jsx
+++ b/frontend/src/context/TranscriptionContext.jsx
@@ -137,7 +137,7 @@ export const TranscriptionProvider = ({ children }) => {
         const formData = new FormData();
         formData.append('file', file.originFileObj);
         
-        const response = await fetch(`${API_BASE_URL}/upload-temp`, {
+        const response = await fetch(`${API_BASE_URL}/upload`, {
           method: 'POST',
           body: formData,
         });


### PR DESCRIPTION
取消langchain導入